### PR TITLE
Fixed getAllRecipes & getPopularRecipes controllers

### DIFF
--- a/controllers/popular-recipe-controllers/getPopularRecipes.js
+++ b/controllers/popular-recipe-controllers/getPopularRecipes.js
@@ -1,9 +1,17 @@
 import { Recipe } from "../../models/recipe/index.js";
 
+const defaultDocNumber = 4;
+
 const getPopularRecipes = async (req, res, next) => {
+  const isNumberSet = Boolean(req.query.number_of_popular);
+
+  const docNumber = isNumberSet
+    ? Number(req.query.number_of_popular)
+    : defaultDocNumber;
+
   const result = await Recipe.aggregate([
     { $sort: { favorite: -1 } },
-    { $limit: 10 },
+    { $limit: docNumber },
   ]);
 
   res.json(result);

--- a/controllers/recipes-controllers/getAllRecipes.js
+++ b/controllers/recipes-controllers/getAllRecipes.js
@@ -1,19 +1,20 @@
 import { Recipe } from "../../models/recipe/index.js";
-import { categoryList } from "../../constants/index.js";
 
 const successStatus = 200;
+const defaultDocNumber = 3;
 
 const getAllRecipes = async (req, res) => {
-  // const { limitStr = 3 } = req.query;
-  // const limit = Number(limitStr);
-  // console.log(typeof limit);
+  const isNumberSet = Boolean(req.query.number_of_every);
 
-  // const result = await Recipe.aggregate([
-  //   { $sort: { category: 1 } },
-  //   { $limit: limit },
-  // ]);
+  const docNumber = isNumberSet
+    ? Number(req.query.number_of_every)
+    : defaultDocNumber;
 
-  const result = await Recipe.find().lean();
+  const result = await Recipe.aggregate([
+    { $sort: { category: 1 } },
+    { $group: { _id: "$category", recipes: { $push: "$$ROOT" } } },
+    { $project: { recipes: { $slice: ["$recipes", docNumber] } } },
+  ]);
 
   res.status(successStatus).json(result);
 };


### PR DESCRIPTION
getAllRecipes повертає таку структуру:
[
  {
    "_id": "Shot",
    "recipes": [{},{},{}]
  },
  {
    "_id": "Punch / Party Drink",
    "recipes": [{},{},{}]
  }
]
тобто масив із об'єктами, де _id - це категорія, а recipes - це масив із об'єктами рецептів. За замовчуванням повертається по 3 рецепти, але якщо до строки запиту "прикрутити" "?number_of_every=7", то поверне по 7 рецептів кожної категорії..

getPopularRecipes за замовчуванням повертає 4 рецепти, але якщо до строки запиту "прикрутити" 
"?number_of_popular=5", то поверне 5 рецептів.

Сподіваюся, що фронтенд буде задоволений)))